### PR TITLE
Fix tls

### DIFF
--- a/.travis.CMakeLists.txt
+++ b/.travis.CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.7)
 
 ## Opt in to tests
 add_custom_target(check)
+add_custom_target(stress)
 
 add_subdirectory(fost-boost)
 add_subdirectory(fost-crypto)

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,5 @@ script:
     - cmake . -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -G Ninja
     - ninja
     - ninja check
+    - ninja fost-internet-ssl-tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,8 @@
+project(fost-internet)
+
+if(TARGET stress)
+    set_property(TARGET stress PROPERTY EXCLUDE_FROM_ALL TRUE)
+endif()
+
 add_subdirectory(Cpp)
+add_subdirectory(test)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-11-02  Kirit Saelensminde  <kirit@felspar.com>
+ Add option to verify server certificates on the network connection and force UA to use it
+
 2019-07-17  Kirit Saelensminde  <kirit@felspar.com>
  Add a way to stop a web server instance.
 

--- a/Cpp/fost-inet-test/connection-failures.cpp
+++ b/Cpp/fost-inet-test/connection-failures.cpp
@@ -77,7 +77,8 @@ namespace {
         auto sock = std::make_unique<boost::asio::ip::tcp::socket>(*service);
         // Accept the connection
         server->accept(*sock);
-        server.reset(); // Must destroy it before the connection below is destructed
+        server.reset(); // Must destroy it before the connection below is
+                        // destructed
         network_connection server_cnx(std::move(service), std::move(sock));
         // Send a few KB of data
         std::string data(10240, '*');

--- a/Cpp/fost-inet/connection.cpp
+++ b/Cpp/fost-inet/connection.cpp
@@ -364,8 +364,8 @@ fostlib::host fostlib::network_connection::remote_end() {
 }
 
 
-network_connection &fostlib::network_connection::
-        operator<<(const const_memory_block &p) {
+network_connection &
+        fostlib::network_connection::operator<<(const const_memory_block &p) {
     const unsigned char *begin = reinterpret_cast<const unsigned char *>(
                                 p.first),
                         *end = reinterpret_cast<const unsigned char *>(
@@ -379,8 +379,8 @@ network_connection &fostlib::network_connection::
     }
     return *this;
 }
-network_connection &fostlib::network_connection::
-        operator<<(const utf8_string &s) {
+network_connection &
+        fostlib::network_connection::operator<<(const utf8_string &s) {
     boost::asio::streambuf b;
     std::ostream os(&b);
     os << s.underlying();
@@ -388,8 +388,8 @@ network_connection &fostlib::network_connection::
     b.consume(length);
     return *this;
 }
-network_connection &fostlib::network_connection::
-        operator<<(const std::stringstream &ss) {
+network_connection &
+        fostlib::network_connection::operator<<(const std::stringstream &ss) {
     return this->operator<<(utf8_string{ss.str()});
 }
 
@@ -415,8 +415,8 @@ network_connection &fostlib::network_connection::operator>>(std::string &s) {
     }
     return *this;
 }
-network_connection &fostlib::network_connection::
-        operator>>(std::vector<utf8> &v) {
+network_connection &
+        fostlib::network_connection::operator>>(std::vector<utf8> &v) {
     const std::size_t chunk =
             coerce<std::size_t>(c_large_read_chunk_size.value());
     while (v.size() - m_input_buffer->size()

--- a/Cpp/fost-inet/headers.cpp
+++ b/Cpp/fost-inet/headers.cpp
@@ -104,8 +104,8 @@ namespace {
     // in the DLL initialisation
     const headers_base::content g_stat;
 }
-const headers_base::content &fostlib::headers_base::
-        operator[](const fostlib::string &n) const {
+const headers_base::content &
+        fostlib::headers_base::operator[](const fostlib::string &n) const {
     header_store_type::const_iterator p(m_headers.find(n));
     if (p == m_headers.end())
         return g_stat;
@@ -159,8 +159,8 @@ namespace {
     }
 }
 
-std::ostream &fostlib::
-        operator<<(std::ostream &o, const fostlib::headers_base &headers) {
+std::ostream &fostlib::operator<<(
+        std::ostream &o, const fostlib::headers_base &headers) {
     for (headers_base::const_iterator i(headers.begin()); i != headers.end();
          ++i) {
         std::stringstream ss;
@@ -262,8 +262,8 @@ headers_base::content::const_iterator
     return m_subvalues.end();
 }
 
-std::ostream &fostlib::
-        operator<<(std::ostream &o, const headers_base::content &v) {
+std::ostream &
+        fostlib::operator<<(std::ostream &o, const headers_base::content &v) {
     /// Without the `static_cast` here the Android NDK compiler goes super weird
     o << static_cast<std::string_view>(v.value());
     for (auto const &i : v) {

--- a/Cpp/fost-inet/http.server.cpp
+++ b/Cpp/fost-inet/http.server.cpp
@@ -253,8 +253,8 @@ fostlib::host fostlib::http::server::request::remote_address() const {
 }
 
 
-fostlib::nullable<fostlib::json> fostlib::http::server::request::
-        operator[](const jcursor &pos) const {
+fostlib::nullable<fostlib::json>
+        fostlib::http::server::request::operator[](const jcursor &pos) const {
     if (pos.size()) {
         const auto size = pos.size();
         if (pos[0] == "headers" && (size == 2 || size == 3)) {
@@ -292,8 +292,8 @@ boost::shared_ptr<fostlib::binary_body>
 }
 
 
-void fostlib::http::server::request::
-        operator()(mime &response, const ascii_string &status) {
+void fostlib::http::server::request::operator()(
+        mime &response, const ascii_string &status) {
     m_handler(response, status);
 }
 
@@ -354,8 +354,8 @@ nliteral fostlib::http::server::status_text(int code) {
 }
 
 
-void fostlib::http::server::request::
-        operator()(mime &response, const int status) {
+void fostlib::http::server::request::operator()(
+        mime &response, const int status) {
     std::stringstream ss;
     ss << status << " " << status_text(status);
     (*this)(response, ascii_string{ss.str()});

--- a/Cpp/fost-inet/http.useragent.cpp
+++ b/Cpp/fost-inet/http.useragent.cpp
@@ -63,8 +63,9 @@ std::unique_ptr<http::user_agent::response>
         if (authentication()) authentication()(req);
 
         network_connection cnx(req.address().server(), req.address().port());
-        if (req.address().protocol() == ascii_printable_string("https"))
-            cnx.start_ssl();
+        if (req.address().protocol() == "https") {
+            cnx.start_ssl(req.address().server().name());
+        }
 
         std::stringstream buffer;
         buffer << coerce<utf8_string>(req.method()).underlying() << " "

--- a/Cpp/fost-inet/http.useragent.cpp
+++ b/Cpp/fost-inet/http.useragent.cpp
@@ -44,8 +44,8 @@ fostlib::http::user_agent::user_agent() {}
 fostlib::http::user_agent::user_agent(const url &u) : base(u) {}
 
 
-std::unique_ptr<http::user_agent::response> fostlib::http::user_agent::
-        operator()(request &req) const {
+std::unique_ptr<http::user_agent::response>
+        fostlib::http::user_agent::operator()(request &req) const {
     try {
         if (!req.headers().exists("Date")) {
             req.headers().set(

--- a/Cpp/include/fost/connection.hpp
+++ b/Cpp/include/fost/connection.hpp
@@ -57,6 +57,9 @@ namespace fostlib {
         /// Start SSL on this connection. After a successful handshake all
         /// traffic will be over SSL.
         void start_ssl();
+        /// Start a SSL connection and verify the server connection for the
+        /// specified host name.
+        void start_ssl(f5::u8view hostname);
 
         /// Return the remote end
         host remote_end();

--- a/Examples/fget/fget.cpp
+++ b/Examples/fget/fget.cpp
@@ -17,7 +17,7 @@ using namespace fostlib;
 FSL_MAIN(
         "fget",
         "Simple HTTP client\n"
-        "Copyright (C) 2008-2019, Felspar Co. Ltd.")
+        "Copyright (c) 2008-2019 Red Anchor Trading Co. Ltd.")
 (fostlib::ostream &o, fostlib::arguments &args) {
     args.commandSwitch("socks", "Network settings", "Socks version");
 

--- a/Examples/fget/fget.cpp
+++ b/Examples/fget/fget.cpp
@@ -22,8 +22,7 @@ FSL_MAIN(
     args.commandSwitch("socks", "Network settings", "Socks version");
 
     // The URL to be fetched (default to localhost)
-    string location = args[1].value_or(L"http://localhost/");
-    o << location << std::endl;
+    string location = args[1].value_or("http://localhost/");
     // Create a user agent and request the URL
     http::user_agent browser;
     http::user_agent::request request("GET", url(location));
@@ -46,7 +45,7 @@ FSL_MAIN(
     auto response(browser(request));
     if (not args[2]) {
         // Display the body
-        o << response->body() << std::endl;
+        o << response->body()->body_as_string() << std::endl;
     } else {
         // Save the body to disk
         fostlib::ofstream file(

--- a/Examples/fget/fget.cpp
+++ b/Examples/fget/fget.cpp
@@ -26,7 +26,9 @@ FSL_MAIN(
     // Create a user agent and request the URL
     http::user_agent browser;
     http::user_agent::request request("GET", url(location));
-    if (args.commandSwitch("authenticate") == "FOST") {
+    if (not args.commandSwitch("authenticate").has_value()) {
+        // Do nothing as there is no authentication mechanism
+    } else if (args.commandSwitch("authenticate") == "FOST") {
         std::set<fostlib::string> tosign;
         if (args.commandSwitch("user")) {
             request.headers().set(
@@ -41,6 +43,10 @@ FSL_MAIN(
         fost_authentication(
                 browser, args.commandSwitch("key").value(),
                 args.commandSwitch("secret").value(), tosign);
+    } else {
+        o << "Unknown authentication mechanism "
+          << args.commandSwitch("authenticate") << std::endl;
+        return 4;
     }
     auto response(browser(request));
     if (not args[2]) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(tls)

--- a/test/tls/CMakeLists.txt
+++ b/test/tls/CMakeLists.txt
@@ -1,0 +1,22 @@
+if(TARGET stress)
+    add_executable(test-ssl EXCLUDE_FROM_ALL test-ssl.cpp)
+    target_link_libraries(test-ssl fost-cli fost-inet)
+
+    set(fost-internet-ssl-test-list)
+    macro(ssltest host pass)
+        add_custom_command(OUTPUT fost-internet-ssl-test-${host}
+            COMMAND test-ssl -b false
+                "https://${host}/" -o fost-internet-ssl-test-${host}
+            DEPENDS test-ssl)
+        list(APPEND fost-internet-ssl-test-list fost-internet-ssl-test-${host})
+    endmacro()
+
+    ssltest(sha256.badssl.com TRUE)
+    ssltest(sha384.badssl.com TRUE)
+    ssltest(sha512.badssl.com TRUE)
+
+    add_custom_target(fost-internet-ssl-tests
+        DEPENDS ${fost-internet-ssl-test-list})
+    set_property(TARGET fost-internet-ssl-tests  PROPERTY EXCLUDE_FROM_ALL TRUE)
+    add_dependencies(stress fost-internet-ssl-tests)
+endif()

--- a/test/tls/CMakeLists.txt
+++ b/test/tls/CMakeLists.txt
@@ -11,12 +11,27 @@ if(TARGET stress)
         list(APPEND fost-internet-ssl-test-list fost-internet-ssl-test-${host})
     endmacro()
 
+    ## These tests are executed against https://badssl.com/ which contains
+    ## a large number of TLS/SSL test cases. Only the most important are
+    ## currently checked.
     ssltest(sha256.badssl.com true)
     ssltest(sha384.badssl.com true)
     ssltest(sha512.badssl.com true)
 
     ssltest(not-valid.example.com false)
     ssltest(expired.badssl.com false)
+    ssltest(wrong.host.badssl.com false)
+    ssltest(self-signed.badssl.com false)
+    ssltest(untrusted-root.badssl.com false)
+
+    ssltest(1000-sans.badssl.com true)
+
+    ## The following return the wrong results. These tests are just to mark
+    ## the current behaviour and to notify any changes due to changes in
+    ## the underlying Boost/ASIO/OpenSSL libraries being used.
+    ssltest(revoked.badssl.com true)
+    ssltest(pinning-test.badssl.com true)
+    ssltest(10000-sans.badssl.com false)
 
     add_custom_target(fost-internet-ssl-tests
         DEPENDS ${fost-internet-ssl-test-list})

--- a/test/tls/CMakeLists.txt
+++ b/test/tls/CMakeLists.txt
@@ -16,6 +16,7 @@ if(TARGET stress)
     ssltest(sha512.badssl.com true)
 
     ssltest(not-valid.example.com false)
+    ssltest(expired.badssl.com false)
 
     add_custom_target(fost-internet-ssl-tests
         DEPENDS ${fost-internet-ssl-test-list})

--- a/test/tls/CMakeLists.txt
+++ b/test/tls/CMakeLists.txt
@@ -5,15 +5,17 @@ if(TARGET stress)
     set(fost-internet-ssl-test-list)
     macro(ssltest host pass)
         add_custom_command(OUTPUT fost-internet-ssl-test-${host}
-            COMMAND test-ssl -b false
+            COMMAND test-ssl -b false -w ${pass}
                 "https://${host}/" -o fost-internet-ssl-test-${host}
             DEPENDS test-ssl)
         list(APPEND fost-internet-ssl-test-list fost-internet-ssl-test-${host})
     endmacro()
 
-    ssltest(sha256.badssl.com TRUE)
-    ssltest(sha384.badssl.com TRUE)
-    ssltest(sha512.badssl.com TRUE)
+    ssltest(sha256.badssl.com true)
+    ssltest(sha384.badssl.com true)
+    ssltest(sha512.badssl.com true)
+
+    ssltest(not-valid.example.com false)
 
     add_custom_target(fost-internet-ssl-tests
         DEPENDS ${fost-internet-ssl-test-list})

--- a/test/tls/test-ssl.cpp
+++ b/test/tls/test-ssl.cpp
@@ -12,8 +12,18 @@
 
 
 namespace {
-    const fostlib::setting<std::optional<fostlib::string>>
-            c_output(__FILE__, "test-ssl", "Output file", fostlib::null, true);
+    const fostlib::setting<std::optional<fostlib::string>> c_output{
+            __FILE__, "test-ssl", "Output file", fostlib::null, true};
+    const fostlib::setting<bool> c_works{
+            __FILE__, "test-ssl", "Valid TLS and certificates", true, true};
+
+    void worked() {
+        if (c_output.value()) {
+            fostlib::utf::save_file(
+                    fostlib::coerce<fostlib::fs::path>(c_output.value().value()),
+                    "");
+        }
+    }
 }
 
 
@@ -23,17 +33,28 @@ FSL_MAIN(
         "Copyright (c) 2008-2019 Red Anchor Trading Co. Ltd.")
 (fostlib::ostream &o, fostlib::arguments &args) {
     args.commandSwitch("o", c_output);
+    args.commandSwitch("w", c_works);
 
     // The URL to be fetched (default to localhost)
     fostlib::string location = args[1].value_or("http://badssl.com/");
     // Create a user agent and request the URL
-    fostlib::http::user_agent browser;
-    fostlib::http::user_agent::request request("GET", fostlib::url{location});
-    auto response(browser(request));
-    if (c_output.value()) {
-        fostlib::utf::save_file(
-                fostlib::coerce<fostlib::fs::path>(c_output.value().value()),
-                "");
+    try {
+        fostlib::http::user_agent browser;
+        fostlib::http::user_agent::request request(
+                "GET", fostlib::url{location});
+        auto response(browser(request));
+        if (c_works.value()) {
+            worked();
+            return 0;
+        } else {
+            return 1;
+        }
+    } catch (fostlib::exceptions::exception &e) {
+        if (c_works.value()) {
+            return 2;
+        } else {
+            worked();
+            return 0;
+        }
     }
-    return 0;
 }

--- a/test/tls/test-ssl.cpp
+++ b/test/tls/test-ssl.cpp
@@ -1,0 +1,39 @@
+/**
+    Copyright 2008-2019 Red Anchor Trading Co. Ltd.
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+ */
+
+
+#include <fost/cli>
+#include <fost/main>
+#include <fost/http>
+
+
+namespace {
+    const fostlib::setting<std::optional<fostlib::string>>
+            c_output(__FILE__, "test-ssl", "Output file", fostlib::null, true);
+}
+
+
+FSL_MAIN(
+        "test-ssl",
+        "Check HTTPS connections and failures\n"
+        "Copyright (c) 2008-2019 Red Anchor Trading Co. Ltd.")
+(fostlib::ostream &o, fostlib::arguments &args) {
+    args.commandSwitch("o", c_output);
+
+    // The URL to be fetched (default to localhost)
+    fostlib::string location = args[1].value_or("http://badssl.com/");
+    // Create a user agent and request the URL
+    fostlib::http::user_agent browser;
+    fostlib::http::user_agent::request request("GET", fostlib::url{location});
+    auto response(browser(request));
+    if (c_output.value()) {
+        fostlib::utf::save_file(
+                fostlib::coerce<fostlib::fs::path>(c_output.value().value()),
+                "");
+    }
+    return 0;
+}

--- a/test/tls/test-ssl.cpp
+++ b/test/tls/test-ssl.cpp
@@ -42,19 +42,26 @@ FSL_MAIN(
         fostlib::http::user_agent browser;
         fostlib::http::user_agent::request request(
                 "GET", fostlib::url{location});
-        auto response(browser(request));
+        auto response = browser(request);
         if (c_works.value()) {
             worked();
             return 0;
         } else {
+            o << "No exception was thrown when one was expected\n";
+            o << response->body()->body_as_string() << std::endl;
             return 1;
         }
     } catch (fostlib::exceptions::exception &e) {
-        if (c_works.value()) {
-            return 2;
-        } else {
+        if (not c_works.value()) {
             worked();
             return 0;
+        } else {
+            o << e << std::endl;
+            return 2;
         }
+    } catch (std::exception &e) {
+        std::cerr << "Caught a std::exception " << typeid(e).name() << '\n';
+        std::cerr << e.what() << std::endl;
+        return 3;
     }
 }


### PR DESCRIPTION
This adds proper TLS/SSL certificate verification. On the TCP connection this is an option chosen by passing the host name to `start_tls` (which also sets the SNI name to be used).

The user agent has been changed to make use of this. This has been done in such a way that it is not possible to opt out of it for a HTTP request. Given the existence of Let's Encrypt I think this is fine, and far less error prone.

Only the most important certificate checking tests are done. Some that we would ideally like to pass are failing, they are marked as such in the CMakeLists.txt configuration.