### PR TITLE
Setting exceptions as expected outcomes in tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2020-02-09  Kirit Saelensminde  <kirit@felspar.com>
+ Can now set exceptions as expected outcomes from the HTTP cache.
+
 2020-01-22  Kirit Saelensminde  <kirit@felspar.com>
  Add high level user agent with test expectation support.
 

--- a/Cpp/fost-inet/http.cache.cpp
+++ b/Cpp/fost-inet/http.cache.cpp
@@ -176,7 +176,7 @@ void fostlib::ua::expect(
 
 
 f5::u8string fostlib::ua::cache_key(
-        f5::u8view method, url const &u, headers const &) {
+        f5::u8view method, url const &u, headers const &headers) {
     fostlib::digester hash{fostlib::sha256};
     if (u.fragment()) {
         auto uf = u;
@@ -184,6 +184,11 @@ f5::u8string fostlib::ua::cache_key(
         hash << method << " " << uf.as_string() << "\n";
     } else {
         hash << method << " " << u.as_string() << "\n";
+    }
+    if (headers.exists("Authorization")) {
+        hash << "Authorization: "
+             << fostlib::coerce<fostlib::string>(headers["Authorization"])
+             << "\n";
     }
     return f5::u8view{fostlib::coerce<fostlib::base32c_string>(
                               array_view<const unsigned char>{hash.digest()})}

--- a/Cpp/fost-inet/http.cache.tests.cpp
+++ b/Cpp/fost-inet/http.cache.tests.cpp
@@ -97,7 +97,7 @@ FSL_TEST_FUNCTION(expectations) {
 
 FSL_TEST_FUNCTION(cache_keys) {
     using fostlib::url;
-    fostlib::ua::headers headers;
+    fostlib::ua::headers const headers;
     FSL_CHECK_EQ(
             fostlib::ua::cache_key("GET", url{"http://localhost/"}, headers),
             "964dyfcyk487v6wzdsajacmxkj0zrgc6mk1bdmprd3vzjvd83h90");
@@ -124,6 +124,14 @@ FSL_TEST_FUNCTION(cache_keys) {
             fostlib::ua::cache_key(
                     "GET", url{"http://localhost/?foo=bar"}, headers),
             "qw4cs8ygp1raksja7sps5m626jsynpkjkcg3ravxnkswe8f0rh2g");
+
+    /// The `Authorization` must result in a different hash key
+    auto authorization = headers;
+    authorization.add("Authorization", "bearer=FOO");
+    FSL_CHECK_EQ(
+            fostlib::ua::cache_key(
+                    "GET", url{"http://localhost/"}, authorization),
+            "hc16ja53bhwz2c2dns53eb1gb6qsmn4cthqadm14tncfhsa9a3v0");
 
     /// The following changes must not result in different cache keys
     FSL_CHECK_EQ(

--- a/Cpp/include/fost/ua/cache.hpp
+++ b/Cpp/include/fost/ua/cache.hpp
@@ -77,6 +77,26 @@ namespace fostlib::ua {
     /// Set an expectation for a request
     void expect(
             f5::u8view method, url const &, json, headers const & = headers{});
+    /// Set an expectation that request processing will throw
+    void
+            expect(f5::u8view method,
+                   url const &,
+                   std::exception_ptr expected,
+                   headers const & = headers{});
+    template<typename E>
+    inline std::enable_if_t<std::is_base_of_v<std::exception, E>>
+            expect(f5::u8view method,
+                   url const &url,
+                   E &&expected,
+                   headers const &h = headers{}) {
+        try {
+            throw expected;
+        } catch (std::exception &) {
+            expect(method, url, std::current_exception(), h);
+        }
+    }
+
+    /// Wrappers for common APIs
     inline void expect_get(url const &u, json b, headers const &h = headers{}) {
         expect("GET", u, b, h);
     }


### PR DESCRIPTION
This allows the UA cache to be told to store exceptions as an expected outcome of HTTP requests in tests.