### PR TITLE
Unicode processing bug fix

### DIFF
--- a/Cpp/fost-inet/http.cache.cpp
+++ b/Cpp/fost-inet/http.cache.cpp
@@ -55,7 +55,12 @@ namespace {
             fostlib::url url,
             std::optional<fostlib::json> body,
             fostlib::ua::headers headers) {
-        headers.add("Accept", "application/json");
+        if (not headers.exists("Accept")) {
+            headers.add("Accept", "application/json");
+        }
+        if (body && not headers.exists("Content-Type")) {
+            headers.add("Content-Type", "application/json");
+        }
         fostlib::http::user_agent ua;
         for (std::size_t count{}; count < 5; ++count) {
             std::shared_ptr<fostlib::mime> body_data;

--- a/Cpp/fost-inet/mime.cpp
+++ b/Cpp/fost-inet/mime.cpp
@@ -60,8 +60,8 @@ fostlib::mime::const_iterator fostlib::mime::end() const {
 }
 
 
-/*
-    fostlib::mime::const_iterator
+/**
+    ## fostlib::mime::const_iterator
 */
 
 
@@ -95,16 +95,16 @@ bool fostlib::mime::const_iterator::operator!=(const const_iterator &o) const {
 }
 
 
-/*
-    fostlib::mime::iterator_implementation
+/**
+    ## fostlib::mime::iterator_implementation
 */
 
 
 fostlib::mime::iterator_implementation::~iterator_implementation() = default;
 
 
-/*
-    fostlib::mime::mime_headers
+/**
+    ## fostlib::mime::mime_headers
 */
 
 std::pair<string, headers_base::content> fostlib::mime::mime_headers::value(
@@ -148,8 +148,8 @@ std::pair<string, headers_base::content> fostlib::mime::mime_headers::value(
 }
 
 
-/*
-    fostlib::empty_mime
+/**
+    ## fostlib::empty_mime
 */
 
 
@@ -181,8 +181,8 @@ std::unique_ptr<mime::iterator_implementation>
 }
 
 
-/*
-    fostlib::mime_envelope
+/**
+    ## fostlib::mime_envelope
 */
 
 
@@ -292,8 +292,8 @@ std::unique_ptr<mime::iterator_implementation>
 }
 
 
-/*
-    fostlib::text_body
+/**
+    ## fostlib::text_body
 */
 
 
@@ -430,8 +430,8 @@ std::unique_ptr<mime::iterator_implementation>
 }
 
 
-/*
-    fostlib::file_body
+/**
+    ## fostlib::file_body
 */
 
 

--- a/Cpp/fost-inet/mime.cpp
+++ b/Cpp/fost-inet/mime.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 1999-2019 Red Anchor Trading Co. Ltd.
+    Copyright 1999-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -35,19 +35,14 @@ fostlib::mime::~mime() {}
 
 
 f5::u8string fostlib::mime::body_as_string() const {
-    f5::u8string string;
-    for (fostlib::mime::const_iterator i(begin()); i != end(); ++i) {
-        f5::u8string data(fostlib::coerce<fostlib::utf8_string>(*i));
-        if (data.bytes() < bytes(*i)) {
-            fostlib::exceptions::not_implemented err{__PRETTY_FUNCTION__,
-                                                     "Not all data converted"};
-            fostlib::insert(err.data(), "data", "bytes", data.bytes());
-            fostlib::insert(err.data(), "bytes", bytes(*i));
-            throw err;
-        }
-        string = string + data;
+    std::string str;
+    for (auto const &i : *this) {
+        str.append(
+                reinterpret_cast<char const *>(i.first),
+                reinterpret_cast<char const *>(i.second));
     }
-    return string;
+    fostlib::utf8_string_tag::check_encoded(str);
+    return f5::u8string{std::move(str)};
 }
 
 


### PR DESCRIPTION
Fixes a bug in the conversion of MIME buffers to strings where UTF-8 continuation bytes that fall at the end of a buffer could cause an invalid Unicode exception to be thrown.

Also ensures that the correct headers are present in HTTP requests for the user agent cache.