### PR TITLE
Use a re-interpret cast instead of fixed type

### DIFF
--- a/Cpp/include/fost/mime.hpp
+++ b/Cpp/include/fost/mime.hpp
@@ -261,7 +261,7 @@ namespace fostlib {
     /// Allow the conversion of MIME subclasses
     template<typename T, typename F>
     struct coercer<T, F, std::enable_if_t<std::is_base_of_v<mime, F>>> {
-        T coerce(const F &f) { return fostlib::coerce<T, mime>(f); }
+        T coerce(F &f) { return fostlib::coerce<T>(reinterpret_cast<mime const &>(f)); }
     };
 
 

--- a/Cpp/include/fost/mime.hpp
+++ b/Cpp/include/fost/mime.hpp
@@ -261,7 +261,7 @@ namespace fostlib {
     /// Allow the conversion of MIME subclasses
     template<typename T, typename F>
     struct coercer<T, F, std::enable_if_t<std::is_base_of_v<mime, F>>> {
-        T coerce(F &f) { return fostlib::coerce<T>(reinterpret_cast<mime const &>(f)); }
+        T coerce(F const &f) { return fostlib::coerce<T>(reinterpret_cast<mime const &>(f)); }
     };
 
 


### PR DESCRIPTION
This ensures that the `from` type is a deduced type, which is important for when the `coerce` mechanism does perfect forwarding properly.

https://github.com/hotkit/fost-base/pull/31 will break this code if this is not done first.