### PR TITLE
General refactoring

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2020-04-23  Kirit Saelensminde  <kirit@felspar.com>
+ * Deprecate a number of uses of wide character literals.
+
 2020-02-09  Kirit Saelensminde  <kirit@felspar.com>
  Can now set exceptions as expected outcomes from the HTTP cache.
 

--- a/Cpp/fost-inet-test/CMakeLists.txt
+++ b/Cpp/fost-inet-test/CMakeLists.txt
@@ -7,6 +7,7 @@ if(TARGET stress)
             connection-failures.cpp
             data-transmission.cpp
             host.cpp
+            http.cpp
             user_agent.cpp
         )
     target_link_libraries(fost-inet-test fost-inet)

--- a/Cpp/fost-inet-test/http.cpp
+++ b/Cpp/fost-inet-test/http.cpp
@@ -1,0 +1,16 @@
+/**
+    Copyright 2020 Red Anchor Trading Co. Ltd.
+
+    Distributed under the Boost Software License, Version 1.0.
+    See <http://www.boost.org/LICENSE_1_0.txt>
+ */
+
+
+#include "fost-inet-test.hpp"
+#include <fost/test>
+
+
+FSL_TEST_SUITE(http);
+
+
+FSL_TEST_FUNCTION(basic_request) {}

--- a/Cpp/fost-inet-test/http.cpp
+++ b/Cpp/fost-inet-test/http.cpp
@@ -30,4 +30,3 @@ FSL_TEST_FUNCTION(basic_request) {
     auto const response = ua.get(fostlib::url{"http://127.0.0.1:45634"});
     FSL_CHECK_EQ(response->status(), 200);
 }
-

--- a/Cpp/fost-inet-test/http.cpp
+++ b/Cpp/fost-inet-test/http.cpp
@@ -9,8 +9,26 @@
 #include "fost-inet-test.hpp"
 #include <fost/test>
 
+#include <fost/http.useragent.hpp>
+#include <fost/http.server.hpp>
+
+
+using namespace std::chrono_literals;
+
 
 FSL_TEST_SUITE(http);
 
 
-FSL_TEST_FUNCTION(basic_request) {}
+FSL_TEST_FUNCTION(basic_request) {
+    std::thread{[]() {
+        fostlib::http::server server{{127, 0, 0, 1}, 45634};
+        auto req = server();
+        fostlib::text_body response{"OK"};
+        (*req)(response);
+    }}.detach();
+    fostlib::http::user_agent ua{{}};
+    std::this_thread::sleep_for(100ms); // TODO use some proper synchronization
+    auto const response = ua.get(fostlib::url{"http://127.0.0.1:45634"});
+    FSL_CHECK_EQ(response->status(), 200);
+}
+

--- a/Cpp/fost-inet-test/http.cpp
+++ b/Cpp/fost-inet-test/http.cpp
@@ -20,14 +20,13 @@ FSL_TEST_SUITE(http);
 
 
 FSL_TEST_FUNCTION(basic_request) {
-    std::thread{[]() {
-        fostlib::http::server server{{127, 0, 0, 1}, 45634};
+    fostlib::http::server server{{127, 0, 0, 1}, 45634};
+    std::thread{[&server]() {
         auto req = server();
         fostlib::text_body response{"OK"};
         (*req)(response);
     }}.detach();
     fostlib::http::user_agent ua{{}};
-    std::this_thread::sleep_for(100ms); // TODO use some proper synchronization
     auto const response = ua.get(fostlib::url{"http://127.0.0.1:45634"});
     FSL_CHECK_EQ(response->status(), 200);
 }

--- a/Cpp/fost-inet-test/pop3.cpp
+++ b/Cpp/fost-inet-test/pop3.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2009-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2009-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -23,7 +23,7 @@ FSL_TEST_FUNCTION(download_messages) {
     FSL_CHECK_NOTHROW(iterate_mailbox(
             host, [&mail_count](const auto &) { return ++mail_count > 10; },
             c_pop3_test_account.value(),
-            setting<string>::value(L"POP3 client test", L"Password")));
+            setting<string>::value("POP3 client test", "Password")));
 }
 
 
@@ -34,16 +34,16 @@ FSL_TEST_FUNCTION(sending_tests) {
     smtp_client server(host, port);
 
     text_body mail(
-            L"This message shows that messages can be sent from "
-            L"appservices.felspar.com");
-    mail.headers().set(L"Subject", L"Test email -- send directly via SMTP");
+            "This message shows that messages can be sent from "
+            "appservices.felspar.com");
+    mail.headers().set("Subject", "Test email -- send directly via SMTP");
     FSL_CHECK_NOTHROW(server.send(
             mail, "pop3test@felspar.com", "appservices@felspar.com"));
 
     text_body should_be_bounced(
-            L"This should be a bounced message. It shows that bounce messages "
-            L"are being received.");
-    mail.headers().set(L"Subject", L"Test email -- sent to invalid address");
+            "This should be a bounced message. It shows that bounce messages "
+            "are being received.");
+    mail.headers().set("Subject", "Test email -- sent to invalid address");
     FSL_CHECK_NOTHROW(server.send(
             should_be_bounced, "not-valid@felspar.com", "pop3test@felspar.com"));
 }

--- a/Cpp/fost-inet-test/smtp.cpp
+++ b/Cpp/fost-inet-test/smtp.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2008-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2008-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -49,7 +49,7 @@ FSL_TEST_FUNCTION(from_string_plain) {
 FSL_TEST_FUNCTION(smtp_send) {
     smtp_client server(host(c_smtp_host.value()), c_smtp_port.value());
 
-    text_body mail(L"This is just a simple test email\n\nIgnore/delete it\n");
-    mail.headers().set(L"Subject", L"Test email");
+    text_body mail("This is just a simple test email\n\nIgnore/delete it\n");
+    mail.headers().set("Subject", "Test email");
     server.send(mail, "kirit@felspar.com", "pop3test@felspar.com");
 }

--- a/Cpp/fost-inet-test/tls.cpp
+++ b/Cpp/fost-inet-test/tls.cpp
@@ -78,8 +78,9 @@ FSL_TEST_FUNCTION(specify_multiple_roots) {
             false};
     fostlib::setting<fostlib::json> const digicert_ca{
             "fost-inet-test/tls.cpp", fostlib::c_extra_leaf_certificates,
-            fostlib::json::array_t{{fostlib::digicert_root_ca()},
-                                   {fostlib::lets_encrypt_root()}}};
+            fostlib::json::array_t{
+                    {fostlib::digicert_root_ca()},
+                    {fostlib::lets_encrypt_root()}}};
     fostlib::http::user_agent ua;
     {
         auto const response =

--- a/Cpp/fost-inet/connection.cpp
+++ b/Cpp/fost-inet/connection.cpp
@@ -436,8 +436,9 @@ void fostlib::network_connection::start_ssl() {
 }
 void fostlib::network_connection::start_ssl(f5::u8view hostname, bool verify) {
     try {
-        m_ssl_data = new ssl{*io_service, *m_socket,
-                             static_cast<std::string>(hostname), verify};
+        m_ssl_data =
+                new ssl{*io_service, *m_socket,
+                        static_cast<std::string>(hostname), verify};
     } catch (boost::system::system_error &e) {
         throw exceptions::socket_error(e.code());
     }
@@ -587,8 +588,8 @@ fostlib::exceptions::connect_failure::connect_failure(
 }
 
 
-fostlib::wliteral const fostlib::exceptions::connect_failure::message() const
-        noexcept {
+fostlib::wliteral const
+        fostlib::exceptions::connect_failure::message() const noexcept {
     return L"Network connection failure";
 }
 

--- a/Cpp/fost-inet/headers.cpp
+++ b/Cpp/fost-inet/headers.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 1999-2019 Red Anchor Trading Co. Ltd.
+    Copyright 1999-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -113,13 +113,12 @@ const headers_base::content &
         return (*p).second;
 }
 
-void fostlib::headers_base::set(const string &n) { return set(n, content()); }
-void fostlib::headers_base::set(const string &n, const content &v) {
+void fostlib::headers_base::set(f5::u8view n, content v) {
     m_headers.erase(m_headers.lower_bound(n), m_headers.upper_bound(n));
-    add(n, v);
+    add(n, std::move(v));
 }
-void fostlib::headers_base::add(const string &n, const content &v) {
-    m_headers.insert(m_headers.upper_bound(n), std::make_pair(n, v));
+void fostlib::headers_base::add(f5::u8view n, content v) {
+    m_headers.insert(m_headers.upper_bound(n), std::make_pair(n, std::move(v)));
 }
 void fostlib::headers_base::set_subvalue(
         const string &n, const string &k, const string &v) {
@@ -202,11 +201,10 @@ json fostlib::detail::from_headers(const headers_base &h) {
 
 
 fostlib::headers_base::content::content() {}
-fostlib::headers_base::content::content(nliteral val) : value(val) {}
 fostlib::headers_base::content::content(wliteral val) : value(val) {}
-fostlib::headers_base::content::content(const string &val) : value(val) {}
+fostlib::headers_base::content::content(f5::u8view val) : value(val) {}
 fostlib::headers_base::content::content(
-        const string &val, const std::map<string, string> &args)
+        f5::u8view val, const std::map<string, string> &args)
 : m_subvalues(args.begin(), args.end()), value(val) {}
 fostlib::headers_base::content::content(const json &values, const string &root) {
     try {

--- a/Cpp/fost-inet/http.authentication.cpp
+++ b/Cpp/fost-inet/http.authentication.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2008-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2008-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -33,15 +33,15 @@ namespace {
 
         fostlib::string now =
                 fostlib::coerce<fostlib::string>(fostlib::timestamp::now());
-        request.headers().set(L"X-FOST-Timestamp", now);
+        request.headers().set("X-FOST-Timestamp", now);
         signature << now << "\n";
 
-        fostlib::string to_sign, signd = L"X-FOST-Headers";
+        fostlib::string to_sign, signd = "X-FOST-Headers";
         for (std::set<fostlib::string>::const_iterator i(
                      headers_to_sign.begin());
              i != headers_to_sign.end(); ++i) {
-            to_sign += L"\n" + request.headers()[*i].value();
-            signd += L" " + *i;
+            to_sign += "\n" + request.headers()[*i].value();
+            signd += " " + *i;
         }
         signature << signd << to_sign << "\n";
         if (request.data().begin() != request.data().end())
@@ -55,10 +55,10 @@ namespace {
                                                       .value_or("")
                                                       .underlying());
 
-        request.headers().set(L"X-FOST-Headers", signd);
+        request.headers().set("X-FOST-Headers", signd);
         request.headers().set(
-                L"Authorization",
-                L"FOST " + api_key + L":"
+                "Authorization",
+                "FOST " + api_key + ":"
                         + fostlib::coerce<string>(
                                 fostlib::coerce<fostlib::base64_string>(
                                         signature.digest())));

--- a/Cpp/fost-inet/http.cache.cpp
+++ b/Cpp/fost-inet/http.cache.cpp
@@ -148,8 +148,9 @@ fostlib::json fostlib::ua::request_json(
                 e.used = true;
             }
         } else if (not c_cache_folder.value() && c_force_no_http_requests.value()) {
-            throw no_expectation{"Expectations run out", method, url,
-                                 std::move(body), std::move(headers)};
+            throw no_expectation{
+                    "Expectations run out", method, url, std::move(body),
+                    std::move(headers)};
         } else {
             ret = check_cache(method, url, std::move(body), std::move(headers));
         }
@@ -157,8 +158,9 @@ fostlib::json fostlib::ua::request_json(
     if (expectation_found) {
         return unwrap_or_throw(ret);
     } else if (not c_cache_folder.value() && c_force_no_http_requests.value()) {
-        throw no_expectation{"Expectation was never set", method, url,
-                             std::move(body), std::move(headers)};
+        throw no_expectation{
+                "Expectation was never set", method, url, std::move(body),
+                std::move(headers)};
     } else {
         return check_cache(method, url, std::move(body), std::move(headers));
     }

--- a/Cpp/fost-inet/mime.cpp
+++ b/Cpp/fost-inet/mime.cpp
@@ -157,8 +157,9 @@ std::pair<string, headers_base::content> fostlib::mime::mime_headers::value(
 fostlib::empty_mime::empty_mime(
         const mime_headers &headers, const string &mime_type)
 : mime(headers, mime_type) {
-    if (!this->headers().exists("Content-Length"))
+    if (not this->headers().exists("Content-Length")) {
         this->headers().set("Content-Length", "0");
+    }
 }
 
 

--- a/Cpp/fost-inet/mime.cpp
+++ b/Cpp/fost-inet/mime.cpp
@@ -344,9 +344,9 @@ public mime::iterator_implementation {
             return const_memory_block();
         } else {
             sent = true;
-            return const_memory_block{body.memory().data(),
-                                      body.memory().data()
-                                              + body.memory().size()};
+            return const_memory_block{
+                    body.memory().data(),
+                    body.memory().data() + body.memory().size()};
         }
     }
 };

--- a/Cpp/fost-inet/mime.cpp
+++ b/Cpp/fost-inet/mime.cpp
@@ -24,11 +24,12 @@ using namespace fostlib;
 */
 
 
-fostlib::mime::mime(const mime_headers &h, const string &content_type)
-: content_type(content_type), headers(h) {
-    if (!headers().exists("Content-Type"))
+fostlib::mime::mime(mime_headers h, f5::u8view content_type)
+: content_type{content_type}, headers{std::move(h)} {
+    if (not headers().exists("Content-Type")) {
         headers().set(
-                L"Content-Type", mime::mime_headers::content(content_type));
+                "Content-Type", mime::mime_headers::content{content_type});
+    }
 }
 
 fostlib::mime::~mime() {}
@@ -132,15 +133,15 @@ std::pair<string, headers_base::content> fostlib::mime::mime_headers::value(
                 }
                 if (not argument.second)
                     throw exceptions::parse_error(
-                            L"Message header " + name
-                                    + L" does not have a value for an argument",
+                            "Message header " + name
+                                    + " does not have a value for an argument",
                             para.first);
                 args[argument.first] = argument.second.value();
             }
         }
-        if (name == L"Content-Disposition") // RFC 1867 uses lower case
+        if (name == "Content-Disposition") // RFC 1867 uses lower case
             return std::make_pair(
-                    L"content-disposition", content(disp.first, args));
+                    "content-disposition", content(disp.first, args));
         else
             return std::make_pair(name, content(disp.first, args));
     } else
@@ -156,8 +157,8 @@ std::pair<string, headers_base::content> fostlib::mime::mime_headers::value(
 fostlib::empty_mime::empty_mime(
         const mime_headers &headers, const string &mime_type)
 : mime(headers, mime_type) {
-    if (!this->headers().exists(L"Content-Length"))
-        this->headers().set("Content-Length", L"0");
+    if (!this->headers().exists("Content-Length"))
+        this->headers().set("Content-Length", "0");
 }
 
 
@@ -309,25 +310,16 @@ namespace {
     }
 }
 fostlib::text_body::text_body(
-        const utf8 *begin,
+        utf8 const *begin,
         const utf8 *end,
-        const mime_headers &headers,
-        const string &mime_type)
-: mime(headers, mime_type), text(utf8_string(begin, end)) {
+        mime_headers headers,
+        f5::u8view mime_type)
+: mime(std::move(headers), mime_type), text(utf8_string(begin, end)) {
     do_headers(*this, text(), mime_type);
 }
 fostlib::text_body::text_body(
-        const utf8_string &t,
-        const mime_headers &headers,
-        const string &mime_type)
-: mime(headers, mime_type), text(t) {
-    do_headers(*this, text(), mime_type);
-}
-fostlib::text_body::text_body(
-        const fostlib::string &t,
-        const mime_headers &headers,
-        const fostlib::string &mime_type)
-: mime(headers, mime_type), text(coerce<utf8_string>(t)) {
+        f5::u8view t, mime_headers headers, f5::u8view mime_type)
+: mime(std::move(headers), mime_type), text(t) {
     do_headers(*this, text(), mime_type);
 }
 
@@ -440,9 +432,9 @@ fostlib::file_body::file_body(
         const mime_headers &headers,
         const string &mime_type)
 : mime(headers, mime_type), filename(p) {
-    this->headers().set(L"Content-Transfer-Encoding", L"8bit");
+    this->headers().set("Content-Transfer-Encoding", "8bit");
     this->headers().set(
-            L"Content-Length", coerce<string>(fostlib::fs::file_size(p)));
+            "Content-Length", coerce<string>(fostlib::fs::file_size(p)));
 }
 
 

--- a/Cpp/include/fost/headers.hpp
+++ b/Cpp/include/fost/headers.hpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 1999-2019 Red Anchor Trading Co. Ltd.
+    Copyright 1999-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -67,15 +67,31 @@ namespace fostlib {
         /// Returns true if a specified header exists
         bool exists(const string &) const;
         /// Allows a header to be set, but without any value
-        void set(const string &name);
+        void set(f5::u8view name) { set(name, content{}); }
         /// Allows a header to be given a specified value
-        void set(const string &name, const content &);
+        void set(f5::u8view name, content);
+        void set(f5::u8view name, f5::u8view value) {
+            set(name, content{value});
+        }
+        [[deprecated("Do not use wchar_t literals")]] void
+                set(wchar_t const *n, f5::u8view c) {
+            set(fostlib::string{n}, content{c});
+        }
+        [[deprecated("Do not use wchar_t literals")]] void
+                set(wchar_t const *n, wchar_t const *c) {
+            set(fostlib::string{n}, content{fostlib::string{c}});
+        }
+        [[deprecated("Do not use char const *")]] void
+                set(f5::u8view name, char const *value) {
+            set(name, content{fostlib::string{value}});
+        }
         /// Allows a header to be given a set of values
-        void set(const string &name, const json &j, const string &r = string()) {
+        void set(f5::u8view name, const json &j, f5::u8view r = {}) {
             set(name, content(j, r));
         }
         /// Adds a header with a given name and content
-        void add(const string &name, const content &);
+        void add(f5::u8view name, content);
+        void add(f5::u8view name, f5::u8view c) { add(name, content{c}); }
         /// Allow a specified sub-value on the specified header to be set
         void set_subvalue(const string &name, const string &k, const string &v);
         /// Fetches a header
@@ -98,14 +114,12 @@ namespace fostlib {
           public:
             /// Create empty content for a header value
             content();
-            /// Create header value content from a narrow character literal
-            content(nliteral);
             /// Create header value content from a wide character literal
-            content(wliteral);
+            [[deprecated("Do not use wchar_t literals")]] content(wliteral);
             /// Create header value content from a string
-            content(const string &);
+            content(f5::u8view);
             /// Create header value content from a string with sub-values
-            content(const string &, const std::map<string, string> &);
+            content(f5::u8view, const std::map<string, string> &);
             /// Create header value content from JSON specifying the root key
             explicit content(const json &values, const string &root = string());
 

--- a/Cpp/include/fost/headers.hpp
+++ b/Cpp/include/fost/headers.hpp
@@ -81,6 +81,10 @@ namespace fostlib {
                 set(wchar_t const *n, wchar_t const *c) {
             set(fostlib::string{n}, content{fostlib::string{c}});
         }
+        template<std::size_t N, std::size_t V> // Delete when the below is deleted
+        void set(char const (&n)[N], char const (&v)[V]) {
+            set(f5::u8view{n}, content{f5::u8view{v}});
+        }
         [[deprecated("Do not use char const *")]] void
                 set(f5::u8view name, char const *value) {
             set(name, content{fostlib::string{value}});

--- a/Cpp/include/fost/mime.hpp
+++ b/Cpp/include/fost/mime.hpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 1999-2019 Red Anchor Trading Co. Ltd.
+    Copyright 1999-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -75,7 +75,10 @@ namespace fostlib {
       protected:
         virtual std::unique_ptr<iterator_implementation> iterator() const = 0;
 
-        explicit mime(const mime_headers &headers, const string &content_type);
+        mime(mime_headers headers, f5::u8view content_type);
+        [[deprecated("Do not use char const *")]] mime(
+                mime_headers h, nliteral ct)
+        : mime{std::move(h), fostlib::string{ct}} {}
     };
 
 
@@ -150,19 +153,29 @@ namespace fostlib {
         std::unique_ptr<iterator_implementation> iterator() const;
 
       public:
+        [[deprecated("Use the f5::u8view constructor")]] text_body(
+                utf8 const *begin,
+                utf8 const *end,
+                mime_headers headers = mime_headers(),
+                f5::u8view mime = "text/plain");
         text_body(
-                const utf8 *begin,
-                const utf8 *end,
-                const mime_headers &headers = mime_headers(),
-                const string &mime = "text/plain");
-        text_body(
-                const utf8_string &text,
-                const mime_headers &headers = mime_headers(),
-                const string &mime = "text/plain");
-        text_body(
-                const string &text,
-                const mime_headers &headers = mime_headers(),
-                const string &mime = L"text/plain");
+                f5::u8view text,
+                mime_headers headers = mime_headers(),
+                f5::u8view mime = "text/plain");
+        [[deprecated("Do not use wchar_t literals")]] text_body(
+                wchar_t const *text, mime_headers headers, f5::u8view mime)
+        : text_body{fostlib::string{text}, std::move(headers), mime} {}
+        [[deprecated("Do not use wchar_t literals")]] text_body(
+                f5::u8view text, mime_headers headers, wchar_t const *mime)
+        : text_body{text, std::move(headers), fostlib::string{mime}} {}
+        [[deprecated("Do not use wchar_t literals")]] text_body(
+                wchar_t const *text,
+                mime_headers headers = mime_headers(),
+                wchar_t const *mime = L"text/plain")
+        : text_body(
+                fostlib::string{text},
+                std::move(headers),
+                fostlib::string{mime}) {}
 
         /// Print the MIME out on the stream
         std::ostream &print_on(std::ostream &o) const;

--- a/Examples/webserver-simple/simple.cpp
+++ b/Examples/webserver-simple/simple.cpp
@@ -1,5 +1,5 @@
 /**
-    Copyright 2008-2019 Red Anchor Trading Co. Ltd.
+    Copyright 2008-2020 Red Anchor Trading Co. Ltd.
 
     Distributed under the Boost Software License, Version 1.0.
     See <http://www.boost.org/LICENSE_1_0.txt>
@@ -12,33 +12,34 @@
 #include <fost/http.server.hpp>
 
 
-using namespace fostlib;
-
-
 namespace {
-    setting<string> c_host(L"http-simple", L"Server", L"Bind to", L"localhost");
-    setting<int> c_port(L"http-simple", L"Server", L"Port", 8001);
+    fostlib::setting<fostlib::string>
+            c_host("http-simple", "Server", "Bind to", "localhost");
+    fostlib::setting<int> c_port("http-simple", "Server", "Port", 8001);
 }
 
 
 FSL_MAIN(
-        L"http-simple",
-        L"Simple HTTP server\nCopyright (c) 2008-2016, Felspar Co. Ltd.")
+        "http-simple",
+        "Simple HTTP server\nCopyright (c) 2008-2020, Red Anchor Trading Co. "
+        "Ltd.")
 (fostlib::ostream &o, fostlib::arguments &args) {
-    http::server server(host(args[1].value_or(c_host.value())), c_port.value());
-    o << L"Answering requests on "
-         L"http://"
-      << server.binding() << L":" << server.port() << L"/" << std::endl;
+    fostlib::http::server server(
+            fostlib::host(args[1].value_or(c_host.value())), c_port.value());
+    o << "Answering requests on http://" << server.binding() << ":"
+      << server.port() << "/" << std::endl;
     for (bool process(true); process;) {
-        std::unique_ptr<http::server::request> req(server());
-        o << req->method() << L" " << req->file_spec() << std::endl;
-        text_body response(
-                L"<html><body>This <b>is</b> a response</body></html>",
-                mime::mime_headers(), L"text/html");
+        std::unique_ptr<fostlib::http::server::request> req(server());
+        o << req->method() << " " << req->file_spec() << std::endl;
+        fostlib::text_body response{
+                "<html><body>This <b>is</b> a response</body></html>",
+                {},
+                "text/html"};
         (*req)(response);
-        if (req->data()->headers()[L"Host"].value() == L"localhost")
+        if (req->data()->headers()["Host"].value() == "localhost") {
             process = false;
+        }
     }
-    o << L"Told to exit" << std::endl;
+    o << "Told to exit\n";
     return 0;
 }


### PR DESCRIPTION
Removes a load of uses of `wchar_t` literals and strings and cleans up a number of APIs so that they work better with the new string types.